### PR TITLE
feat: Pretty print moves

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
     "movesShown": 5,
-    "gemManagement": true,
-    "prettyPrint": true
+    "gemManagement": true
 }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
     "movesShown": 5,
-    "gemManagement": true
+    "gemManagement": true,
+    "prettyPrint": true
 }

--- a/src/searchnode.py
+++ b/src/searchnode.py
@@ -50,11 +50,6 @@ class SearchNode(Tile):
                 )
                 else ""
             )
-            + (
-                f"\n{self.pretty_word()}\n"
-                if config["prettyPrint"]
-                else ""
-            )
         )
 
 
@@ -74,26 +69,6 @@ class SearchNode(Tile):
             
         return False
     
-
-    def pretty_word(self):
-        # ANSI escape codes for colors
-        RED = '\033[91m'
-        RESET = '\033[0m'
-        board = [(['█'] * 5) for _ in range(5)]
-
-        for chain_node in self.chain():
-            x, y = chain_node.x, chain_node.y
-
-            if chain_node.swap:
-                board[y][x] = f"{RED}{chain_node.letter}{RESET}"
-            else:
-                board[y][x] = chain_node.letter
-
-        return "\n".join([
-            " ".join(row)
-            for row in board
-        ])
-
 
     def word(self):
         return "".join([

--- a/src/searchnode.py
+++ b/src/searchnode.py
@@ -50,6 +50,11 @@ class SearchNode(Tile):
                 )
                 else ""
             )
+            + (
+                f"\n{self.pretty_word()}\n"
+                if config["prettyPrint"]
+                else ""
+            )
         )
 
 
@@ -69,6 +74,26 @@ class SearchNode(Tile):
             
         return False
     
+
+    def pretty_word(self):
+        # ANSI escape codes for colors
+        RED = '\033[91m'
+        RESET = '\033[0m'
+        board = [(['█'] * 5) for _ in range(5)]
+
+        for chain_node in self.chain():
+            x, y = chain_node.x, chain_node.y
+
+            if chain_node.swap:
+                board[y][x] = f"{RED}{chain_node.letter}{RESET}"
+            else:
+                board[y][x] = chain_node.letter
+
+        return "\n".join([
+            " ".join(row)
+            for row in board
+        ])
+
 
     def word(self):
         return "".join([


### PR DESCRIPTION
First of all, great job on engineering such a wonderful solver. I use it all the time.

### Motivation
In adventure mode where time is really short, rapidly editing the board.txt, waiting for possible moves, identifying where the entire word lies on the GUI board, making the swaps necessary, and finally playing the move (hoping I remember where the entire word lied) can prove to be quite a challenge.

This can be really felt in levels where we are given very less time per move, especially if the board is shuffled after each round (if this happens, updating board.txt takes up valuable time).

While I am working on OCR to save time, I found that pretty printing the moves to be a valuable addition that helps save a lot of time.

### Feature
For each move, a board is printed in the terminal. Letters that are to be swapped are in red. Letters that are not part of the solution are blocked out using filler characters. This helps to better visualize the board.

**Before**
![basic](https://github.com/user-attachments/assets/1af7267c-c005-4101-9155-30d95bebf2ee)

**After**
![pretty](https://github.com/user-attachments/assets/4f8e25ba-cf34-4b5e-872f-44f28758806c)

For people who are not interested in this, they can easily turn it off in config.json