### PR TITLE
fix: typo swap_letter

### DIFF
--- a/src/spellcast.py
+++ b/src/spellcast.py
@@ -76,7 +76,7 @@ class Spellcast(Board):
                     continue
 
                 for swap_letter in dictionary.alphabet:
-                    if letter == adjacent_node.letter:
+                    if swap_letter == adjacent_node.letter:
                         continue
 
                     if not dictionary.has_prefix(current_node_cache["word"] + swap_letter):


### PR DESCRIPTION
I've identified and fixed a typo that was probably made by mistake in this [commit](https://github.com/WintrCat/spellcastsolver/commit/f37d0a922ac454ef25c2fb4dd07e06715d4fda16#diff-883d2bad9036f45b395b053bd73a5dfa79cffaf44c2ea1fdfb5cb7f0fd4a6ca8R75) last month.

Naturally, fixing this speeds up the engine.